### PR TITLE
Use TestNG @Test instead of Junit @Test annotation.

### DIFF
--- a/src/test/java/ActivityDAOTest.java
+++ b/src/test/java/ActivityDAOTest.java
@@ -6,7 +6,6 @@ import cz.muni.fi.pa165.sportsactivitymanager.Entity.Activity;
 import cz.muni.fi.pa165.sportsactivitymanager.Entity.Calories;
 import cz.muni.fi.pa165.sportsactivitymanager.PersistenceSampleApplicationContext;
 import junit.framework.Assert;
-import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.TestExecutionListeners;
@@ -16,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
 
 import javax.persistence.*;
 import java.util.List;
@@ -36,21 +36,22 @@ public class ActivityDAOTest extends AbstractTestNGSpringContextTests {
     private static boolean setup = false;
 
     @Autowired
-    private static ActivityDAO activityDao;
+    private  ActivityDAO activityDao;
 
     @Autowired
-    private static CaloriesDAO caloriesDao;
+    private  CaloriesDAO caloriesDao;
 
     @PersistenceUnit
-    private static EntityManagerFactory emf;
+    private  EntityManagerFactory emf;
 
-    private static EntityManager em;
+    private  EntityManager em;
 
     /**
      * setUp creates and persists 3 Activity objects that the tests run on
      */
     @BeforeMethod
-    public static void setUp() {
+    public  void setUp() {
+        //TODO: FIX ME
         if(!setup){
             System.out.println("setup started");
 


### PR DESCRIPTION
# Fixing the problem

The main problem was that you were using @Test annotation provided by Junit instead of TestNG. Your test is configured to use TestNG-configuration that will startup the Spring ( `extends AbstractTestNGSpringContextTests`) and is not aplicable to Junit. This was probably also a reason why @BeforeTest was not working before. The other annotations are the same and therefore it doesn't matter much which test framework you are using for them.
# Another notes

As we discussed before, I was not much right with the `@ComponentScan(basePackageClasses={UserDao.class})`. What this does is it tells Spring to start scanning the classes from the package in which UserDao is located. This is more convenient than providing some String like "cz.muni.fi.pa165" because this may be subjected to a change that would cause problems. Referencing package-specific class should be more type-safe. Since all your DAOs are placed in the package in which UserDao is placed, this will work as well.
